### PR TITLE
fix: len built-in func never return negative

### DIFF
--- a/app/controllers/base_controller.go
+++ b/app/controllers/base_controller.go
@@ -298,9 +298,6 @@ func GetFlash(w http.ResponseWriter, r *http.Request, name string) []string {
 	}
 
 	fm := session.Flashes(name)
-	if len(fm) < 0 {
-		return nil
-	}
 
 	session.Save(r, w)
 	var flashes []string

--- a/app/controllers/base_controller.go
+++ b/app/controllers/base_controller.go
@@ -298,6 +298,9 @@ func GetFlash(w http.ResponseWriter, r *http.Request, name string) []string {
 	}
 
 	fm := session.Flashes(name)
+	if len(fm) == 0 {
+		return nil
+	}
 
 	session.Save(r, w)
 	var flashes []string


### PR DESCRIPTION
`len` built-in func never return negative.